### PR TITLE
Fix performance issue caused by lazy loading

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.includes(:user).order(played_at: :desc, id: :desc)
       serialized_scores = scores.map(&:serialize)
 
       response = {


### PR DESCRIPTION
Fixes: #1

**Changes**

For each Score object in the list, the mapping of "serialize" function used to trigger a request to the database, in order to lazy load a User object.
N score objects used to lead to N requests to the database for users.

Now, we eager load the users, all in a single request to the database, thus reducing the number of requests from N to 1.


**Before**

![image](https://user-images.githubusercontent.com/94162742/141994452-041e3a3a-a703-4eeb-97a2-75aab2746683.png)



**After**

![image](https://user-images.githubusercontent.com/94162742/141981838-04187810-fbac-4c76-b738-899376927867.png)